### PR TITLE
Mettre à jour les exports du zshrc et régler un problème de fork avec Ruby et MacOS

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -40,12 +40,15 @@ export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/b
 export PATH="/opt/homebrew/bin:$PATH"
 
 # Node
-export PATH="/usr/local/opt/node@14/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/node@14/lib"
-export CPPFLAGS="-I/usr/local/opt/node@14/include"
+export PATH="/usr/local/opt/node@18/bin:$PATH"
+export LDFLAGS="-L/usr/local/opt/node@18/lib"
+export CPPFLAGS="-I/usr/local/opt/node@18/include"
 
 # Ruby
 export RUBYOPT='--enable-yjit'
+
+# Ruby & MacOS bug, issue: https://github.com/rails/rails/issues/38560
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 
 # Load oh-my-zsh
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
Cette PR a pour but de mettre à jour les exports de node à la version 18 pour ceux qui n'utilise pas NVM. J'en profite aussi pour ajouter un export qui règle un bug entre ruby et MacOS.